### PR TITLE
fix: use full relative import for the server package

### DIFF
--- a/src/pagerduty_mcp_server/main.py
+++ b/src/pagerduty_mcp_server/main.py
@@ -5,7 +5,7 @@ import logging
 import sys
 from importlib.metadata import version
 
-from .server import mcp
+from pagerduty_mcp_server.server import mcp
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"


### PR DESCRIPTION
and rename the main file to match pyproject config.

This should also allow the server to be short-hand run via `uvx pagerduty-mcp-server`.