### PR TITLE
fix: use SSH deploy key for semantic-release push

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ commit_message = "chore(release): {version}"
 [tool.semantic_release.commit_parser_opts]
 allowed_types = ["feat", "fix", "chore", "ci", "docs", "style", "refactor", "test"]
 
+[tool.semantic_release.remote]
+ignore_token_for_push = true
+
 [tool.semantic_release.commit_type_map]
 chore = "patch"
 ci = "patch"


### PR DESCRIPTION
## Summary

Branch protection on `main` now requires PRs, which blocks the HTTPS push that `python-semantic-release` does when `GH_TOKEN` is set. It constructs `https://actor:token@github.com/...` and pushes via that, ignoring the SSH remote from `actions/checkout`.

Setting `remote.ignore_token_for_push = true` makes it fall back to the existing SSH remote (the deploy key configured via `GH_ACTIONS_PRIVATE_KEY`), which can bypass the PR requirement. `GH_TOKEN` is still used for GitHub API calls (creating releases).

Fixes [run #24918594963](https://github.com/wpfleger96/pagerduty-mcp-server/actions/runs/24918594963).