### PR TITLE
fix: add PSR v10 changelog insertion flag and backfill missing entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # CHANGELOG
 
+<!-- version list -->
+
+
+## v4.0.1 (2026-05-11)
+
+### Bug Fixes
+
+- Re-enable automatic CHANGELOG generation
+  ([#24](https://github.com/wpfleger96/pagerduty-mcp-server/pull/24),
+  [`2f177b5`](https://github.com/wpfleger96/pagerduty-mcp-server/commit/2f177b53123a03dd7e43970bc42f860f998a9fe4))
+
+PSR v10 removed the default changelog config that v9 inferred automatically. Without an explicit
+  [tool.semantic_release.changelog] section, v10 silently skips CHANGELOG generation on release.
+  Also backfills the v4.0.0 entry that was missing due to this breakage.
+
+### Chores
+
+- **deps-dev**: Bump pytest from 8.4.2 to 9.0.3
+  ([#22](https://github.com/wpfleger96/pagerduty-mcp-server/pull/22),
+  [`5506e99`](https://github.com/wpfleger96/pagerduty-mcp-server/commit/5506e9945bf1276120ec1ebcf21961dcbe59922c))
+
+- **deps**: Bump python-multipart from 0.0.26 to 0.0.27
+  ([#23](https://github.com/wpfleger96/pagerduty-mcp-server/pull/23),
+  [`7bb2450`](https://github.com/wpfleger96/pagerduty-mcp-server/commit/7bb24500c4cf833d757b25034568ce62ce8688c7))
+
 
 ## v4.0.0 (2026-05-11)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,10 @@ allow_zero_version = true
 allowed_types = ["feat", "fix", "chore", "ci", "docs", "style", "refactor", "test"]
 
 [tool.semantic_release.changelog]
-changelog_file = "CHANGELOG.md"
 exclude_commit_patterns = ["chore\\(release\\)"]
+
+[tool.semantic_release.changelog.default_templates]
+changelog_file = "CHANGELOG.md"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Summary

PSR v10 changed `changelog.mode` default from `init` (overwrite) to `update` (insert-in-place). In update mode, `changelog_update.md.j2` splits `CHANGELOG.md` on a `<!-- version list -->` insertion flag — when this flag is absent, the template silently outputs the file unchanged. The previous fix (2f177b5) added the `[changelog]` config section but never inserted this flag, so the v4.0.1 release silently skipped changelog updates.

- Add `<!-- version list -->` insertion flag to `CHANGELOG.md`
- Move `changelog_file` from deprecated `[tool.semantic_release.changelog]` to canonical `[tool.semantic_release.changelog.default_templates]` for PSR v11 compat
- Backfill v4.0.1