### PR TITLE
fix: install uv in PSR Docker container before lockfile sync

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ branch = "main"
 commit_parser = "conventional"
 commit_message = "chore(release): {version}"
 allow_zero_version = true
-build_command = "uv sync"
+build_command = "pip install uv && uv sync"
 
 [tool.semantic_release.commit_parser_opts]
 allowed_types = ["feat", "fix", "chore", "ci", "docs", "style", "refactor", "test"]


### PR DESCRIPTION
## Summary

- PSR's GitHub Action runs `build_command` inside a Docker container (`python:3.14-slim-trixie`) that doesn't have `uv` installed
- `build_command = "uv sync"` fails with exit code 127 (command not found)
- Fix: install `uv` via `pip` (confirmed available in the container's Dockerfile) before running `uv sync`