### PR TITLE
chore: tighten requires-python and remove mypy version pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "pagerduty_mcp_server"
 version = "4.0.2"
 description = "MCP server for LLM agents to interact with PagerDuty SaaS"
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.14"
 license = "MIT"
 authors = [
     { name = "Will Pfleger", email = "pfleger.will@gmail.com" }


### PR DESCRIPTION
## Summary

- Sets `requires-python` to `>=3.14` (was `>=3.13`)

No mypy `python_version` to remove — it was already absent. `.python-version` is the single source of truth for the interpreter version.

Companion to the Renovate PR that bumps `.python-version` to `3.14`.