### PR TITLE
chore: remove pagerduty mypy override (blocked on upstream release)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,7 @@ classifiers = [
 dependencies = [
     "fastmcp>=3",
     "keyring>=24.0.0",
-    # Floor pending the PagerDuty release containing PRs #81 and #83 (mypy
-    # annotation fixes). Replace TODO-RELEASE with the real version once cut.
-    "pagerduty>=TODO-RELEASE",
+    "pagerduty>=6.2.2",
     "pydantic>=2.0.0",
     "python-dotenv>=1.0.0",
     "requests>=2.32.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,9 @@ classifiers = [
 dependencies = [
     "fastmcp>=3",
     "keyring>=24.0.0",
-    "pagerduty>=1.0.0",
+    # Floor pending the PagerDuty release containing PRs #81 and #83 (mypy
+    # annotation fixes). Replace TODO-RELEASE with the real version once cut.
+    "pagerduty>=TODO-RELEASE",
     "pydantic>=2.0.0",
     "python-dotenv>=1.0.0",
     "requests>=2.32.3",
@@ -51,10 +53,6 @@ dev = [
 explicit_package_bases = true
 mypy_path = "src"
 files = ["src/"]
-
-[[tool.mypy.overrides]]
-module = "pagerduty.*"
-follow_imports = "skip"
 
 [tool.setuptools.package-data]
 pagerduty_mcp_server = ["docs/*.md"]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.14"
 resolution-markers = [
     "python_full_version >= '3.15'",
@@ -804,14 +804,14 @@ wheels = [
 
 [[package]]
 name = "pagerduty"
-version = "6.2.1"
+version = "6.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/df/c04b48f1a572fba4fbdd30df5ee84231adddaa60adf73915e0f7b34188de/pagerduty-6.2.1.tar.gz", hash = "sha256:ccab9cc14cb78fef9d1a33919662d620259406c5d764737af09f4b0e9a9264d7", size = 44798, upload-time = "2026-03-03T22:24:11.401Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/36/bd614651ea128057a47fab486ca8f647351320ac19aa998e5aa11ba2cadd/pagerduty-6.2.2.tar.gz", hash = "sha256:c8a7ea625f72b47624decd282c925c8b7fab0568aaae7ad3bd430ce9a15c99d6", size = 44782, upload-time = "2026-06-12T19:55:54.665Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/5f/32170240e7cb5dfd78a68b82047a598c77b810d2e3083ce8317d4f67df7a/pagerduty-6.2.1-py3-none-any.whl", hash = "sha256:38433bf2ec9bd74b2deffef2f9b0e88b897f4d9785646b776c53d88f279e948f", size = 55580, upload-time = "2026-03-03T22:24:10.115Z" },
+    { url = "https://files.pythonhosted.org/packages/50/06/57dc71fa149c6049173fcb47345710ca25cfbbbfef684ed4d5bef31860f5/pagerduty-6.2.2-py3-none-any.whl", hash = "sha256:5a87621f8a75fb874b231333965c8c1a71fa470f1557e9faf9e7f1b650cafe48", size = 55567, upload-time = "2026-06-12T19:55:53.515Z" },
 ]
 
 [[package]]
@@ -841,7 +841,7 @@ dev = [
 requires-dist = [
     { name = "fastmcp", specifier = ">=3" },
     { name = "keyring", specifier = ">=24.0.0" },
-    { name = "pagerduty", specifier = ">=1.0.0" },
+    { name = "pagerduty", specifier = ">=6.2.2" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "requests", specifier = ">=2.32.3" },


### PR DESCRIPTION
Removes the only pagerduty `mypy` workaround in this repo:

```toml
[[tool.mypy.overrides]]
module = "pagerduty.*"
follow_imports = "skip"
```

This override existed solely to mask broken type annotations in the `pagerduty` package (e.g. `def auto_json(method: callable) -> callable`). Those annotations are fixed by [PagerDuty/python-pagerduty#81](https://github.com/PagerDuty/python-pagerduty/pull/81) and [#83](https://github.com/PagerDuty/python-pagerduty/pull/83), released in `pagerduty` 6.2.2. With the fix in the released bytes, the suppression is no longer needed.

The dependency floor is bumped to `pagerduty>=6.2.2` to guarantee the fixed annotations, and `uv.lock` is re-pinned to 6.2.2. `mypy` passes clean against the released package without the override.
