### PR TITLE
chore: add .tokeignore and LOC badge to README

### DIFF
--- a/.tokeignore
+++ b/.tokeignore
@@ -1,0 +1,8 @@
+*.md
+*.json
+*.yaml
+*.yml
+*.toml
+*.lock
+*.mdc
+*.typed

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A server that exposes PagerDuty API functionality to LLMs. This server is design
 [![PyPI Downloads](https://img.shields.io/pypi/dm/pagerduty-mcp-server.svg)](https://pypi.org/project/pagerduty-mcp-server/)
 [![Python Versions](https://img.shields.io/pypi/pyversions/pagerduty-mcp-server.svg)](https://pypi.org/project/pagerduty-mcp-server/)
 [![GitHub Contributors](https://img.shields.io/github/contributors/wpfleger96/pagerduty-mcp-server.svg)](https://github.com/wpfleger96/pagerduty-mcp-server/graphs/contributors)
+[![Lines of Code](https://aschey.tech/tokei/github/wpfleger96/pagerduty-mcp-server?category=code)](https://github.com/wpfleger96/pagerduty-mcp-server)
 [![PyPI version](https://img.shields.io/pypi/v/pagerduty-mcp-server.svg)](https://pypi.org/project/pagerduty-mcp-server/)
 [![License](https://img.shields.io/github/license/wpfleger96/pagerduty-mcp-server.svg)](https://github.com/wpfleger96/pagerduty-mcp-server/blob/main/LICENSE)
 


### PR DESCRIPTION
Adds `.tokeignore` to restrict the tokei badge to Python source and adds the Lines of Code badge to the README.

The repo had no LOC badge, and without a `.tokeignore` tokei counts all tracked files including JSON tool schemas, YAML CI configs, TOML, and Cursor `.mdc` rule files.

- excludes `*.md`, `*.json`, `*.yaml`, `*.yml`, `*.toml`, `*.lock`, `*.mdc`, `*.typed`
- keeps `.py` as the sole counted language
- adds `[![Lines of Code](...)]` badge after the GitHub Contributors badge