### PR TITLE
fix(lint): make ruff config independent of runtime Python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,14 @@ dev = [
     "types-requests>=2.32.0",
 ]
 
+[tool.ruff]
+target-version = "py313"
+
+[tool.ruff.lint]
+# BLE001: broad exception catches are intentional in API error handlers (route to utils.handle_api_error)
+# RUF012: Pydantic BaseModel subclasses handle mutable defaults safely; ruff can't follow multi-level inheritance
+ignore = ["BLE001", "RUF012"]
+
 [tool.mypy]
 explicit_package_bases = true
 mypy_path = "src"

--- a/src/pagerduty_mcp_server/__init__.py
+++ b/src/pagerduty_mcp_server/__init__.py
@@ -5,7 +5,7 @@ A server that exposes PagerDuty API functionality to LLMs. This server is design
 
 from .server import mcp
 
-__all__ = ["mcp", "main"]
+__all__ = ["main", "mcp"]
 
 
 def main():

--- a/src/pagerduty_mcp_server/async_utils.py
+++ b/src/pagerduty_mcp_server/async_utils.py
@@ -2,7 +2,8 @@
 
 import asyncio
 import logging
-from typing import Any, Callable, Dict, List
+from collections.abc import Callable
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -41,11 +42,11 @@ async def safe_execute_async(func: Callable[[], Any], operation_name: str) -> An
 async def paginate(
     pd_client: Any,
     entity: str,
-    params: Dict[str, Any],
+    params: dict[str, Any],
     *,
     max_records: int,
     operation_name: str,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """Iterate a PagerDuty list endpoint, stopping after `max_records` items.
 
     This is the canonical pattern for capping list results from the
@@ -78,8 +79,8 @@ async def paginate(
             "paginate() params must not contain 'limit'; use max_records to cap results."
         )
 
-    def _collect() -> List[Dict[str, Any]]:
-        results: List[Dict[str, Any]] = []
+    def _collect() -> list[dict[str, Any]]:
+        results: list[dict[str, Any]] = []
         optimal_page_size = min(max_records, 100)
         for item in pd_client.iter_all(
             entity, params=params, page_size=optimal_page_size

--- a/src/pagerduty_mcp_server/auth.py
+++ b/src/pagerduty_mcp_server/auth.py
@@ -366,7 +366,9 @@ def get_token():
                 server.handle_request()
 
             if CallbackHandler.error:
-                raise Exception(f"OAuth authorization failed: {CallbackHandler.error}")
+                raise RuntimeError(
+                    f"OAuth authorization failed: {CallbackHandler.error}"
+                )
 
             response = requests.post(
                 OAUTH_TOKEN_URL,
@@ -381,7 +383,7 @@ def get_token():
             )
 
             if response.status_code != 200:
-                raise Exception(f"Token error: {response.text}")
+                raise RuntimeError(f"Token error: {response.text}")
 
             token_data = response.json()
             return _store_tokens(token_data)

--- a/src/pagerduty_mcp_server/client.py
+++ b/src/pagerduty_mcp_server/client.py
@@ -1,7 +1,6 @@
 import logging
 import os
 from importlib.metadata import version
-from typing import Optional
 
 import pagerduty
 from dotenv import load_dotenv
@@ -23,8 +22,8 @@ class _RestClient(pagerduty.RestApiV2Client):
 
 
 class PagerDutyClient:
-    _env_client: Optional[pagerduty.RestApiV2Client] = None
-    _env_token: Optional[str] = None
+    _env_client: pagerduty.RestApiV2Client | None = None
+    _env_token: str | None = None
 
     @staticmethod
     def _get_request_token() -> tuple:
@@ -40,7 +39,7 @@ class PagerDutyClient:
             return False, None
 
     @staticmethod
-    def _get_oauth_token() -> Optional[str]:
+    def _get_oauth_token() -> str | None:
         """Try to get OAuth token from keyring or run interactive OAuth flow for local use.
 
         OAuth is configured if either:
@@ -69,7 +68,7 @@ class PagerDutyClient:
             raise PagerDutyAuthError(str(e)) from e
 
     @staticmethod
-    def _get_env_token() -> Optional[str]:
+    def _get_env_token() -> str | None:
         """Try to get auth token from environment variable.
 
         Returns:

--- a/src/pagerduty_mcp_server/docs/tools.md
+++ b/src/pagerduty_mcp_server/docs/tools.md
@@ -113,13 +113,13 @@ get_escalation_policies(include=["id", "name"])
 
 # Get escalation policies with specific fields and filters combined
 get_escalation_policies(
-    query="production",
-    include=["id", "name", "description"],
-    limit=10
+    query="production", include=["id", "name", "description"], limit=10
 )
 
 # Get details for a specific escalation policy with only certain fields
-get_escalation_policies(policy_id="POLICY_123", include=["id", "name", "escalation_rules"])
+get_escalation_policies(
+    policy_id="POLICY_123", include=["id", "name", "escalation_rules"]
+)
 ```
 
 ## Incidents Tools
@@ -343,9 +343,7 @@ get_incidents(since="2025-02-26T00:00:00Z", until="2025-03-26T00:00:00Z")
 # Get incidents for specific services
 # Use this query to answer questions like "What incidents have been resolved this week for Service 123?"
 get_incidents(
-    current_user_context=False,
-    service_ids=["SERVICE_123"],
-    statuses=["resolved"]
+    current_user_context=False, service_ids=["SERVICE_123"], statuses=["resolved"]
 )
 
 # Get details for a specific incident with additional context
@@ -353,7 +351,7 @@ get_incidents(
     incident_id="INCIDENT_ABC",
     include_past_incidents=True,
     include_related_incidents=True,
-    include_notes=True
+    include_notes=True,
 )
 
 # Get only specific fields for incidents (using include parameter)
@@ -363,11 +361,13 @@ get_incidents(include=["id", "title", "status", "created_at"])
 get_incidents(
     statuses=["triggered", "acknowledged"],
     include=["id", "incident_number", "title", "status", "urgency"],
-    limit=10
+    limit=10,
 )
 
 # Get details for a specific incident with only certain fields
-get_incidents(incident_id="INCIDENT_ABC", include=["id", "title", "status", "assignments"])
+get_incidents(
+    incident_id="INCIDENT_ABC", include=["id", "title", "status", "assignments"]
+)
 ```
 
 ### acknowledge_incident
@@ -409,7 +409,9 @@ The updated incident object in the standard response format (same fields as `get
 resolve_incident(incident_id="INCIDENT_ABC")
 
 # Resolve and return only key fields
-resolve_incident(incident_id="INCIDENT_ABC", include=["id", "title", "status", "resolved_at"])
+resolve_incident(
+    incident_id="INCIDENT_ABC", include=["id", "title", "status", "resolved_at"]
+)
 ```
 
 ### add_incident_note
@@ -435,10 +437,16 @@ The created note object in the standard response format:
 #### Example Queries
 ```python
 # Add a note to an incident
-add_incident_note(incident_id="INCIDENT_ABC", content="Investigating root cause - appears to be a database connection issue")
+add_incident_note(
+    incident_id="INCIDENT_ABC",
+    content="Investigating root cause - appears to be a database connection issue",
+)
 
 # Add a resolution note
-add_incident_note(incident_id="INCIDENT_ABC", content="Resolved by restarting the database connection pool")
+add_incident_note(
+    incident_id="INCIDENT_ABC",
+    content="Resolved by restarting the database connection pool",
+)
 ```
 
 ## On-Call Tools
@@ -512,17 +520,18 @@ Each on-call object contains:
 get_oncalls()
 
 # Find who is currently on-call for a specific schedule
-get_oncalls(current_user_context=False, schedule_ids=['SCHEDULE_123'])
+get_oncalls(current_user_context=False, schedule_ids=["SCHEDULE_123"])
 
 # Find the next on-call shift for the current user
 from datetime import datetime, timedelta
+
 user_context = build_user_context()
 get_oncalls(
     current_user_context=False,
     user_ids=[user_context["user_id"]],
     since=datetime.utcnow().isoformat(),
     until=(datetime.utcnow() + timedelta(days=30)).isoformat(),
-    earliest=True
+    earliest=True,
 )
 
 # Get only specific fields for on-call entries (using include parameter)
@@ -532,7 +541,7 @@ get_oncalls(include=["user", "escalation_level", "start", "end"])
 get_oncalls(
     schedule_ids=["SCHEDULE_123"],
     include=["user", "schedule", "start", "end"],
-    limit=10
+    limit=10,
 )
 
 # Get minimal on-call information for quick overview
@@ -686,7 +695,7 @@ get_schedules(query="Schedule Name")
 get_schedules(
     schedule_id="SCHEDULE_123",
     since="2025-02-27T00:00:00Z",
-    until="2025-03-13T00:00:00Z"
+    until="2025-03-13T00:00:00Z",
 )
 
 # Get only specific fields for schedules (using include parameter)
@@ -694,9 +703,7 @@ get_schedules(include=["id", "name", "time_zone"])
 
 # Get schedules with specific fields and filters combined
 get_schedules(
-    query="production",
-    include=["id", "name", "description", "teams"],
-    limit=5
+    query="production", include=["id", "name", "description", "teams"], limit=5
 )
 
 # Get details for a specific schedule with only certain fields
@@ -761,7 +768,7 @@ list_users_oncall(schedule_id="SCHEDULE_123")
 list_users_oncall(
     schedule_id="SCHEDULE_123",
     since="2025-03-01T00:00:00Z",
-    until="2025-04-01T00:00:00Z"
+    until="2025-04-01T00:00:00Z",
 )
 ```
 
@@ -852,7 +859,7 @@ When getting a specific service (with `service_id`):
 get_services()
 
 # List services for a specific team
-get_services(current_user_context=False, team_ids=['TEAM_123'])
+get_services(current_user_context=False, team_ids=["TEAM_123"])
 
 # Get details for a specific service
 get_services(service_id="SERVICE_123")
@@ -865,9 +872,7 @@ get_services(include=["id", "name", "status"])
 
 # Get services with specific fields and filters combined
 get_services(
-    team_ids=["TEAM_123"],
-    include=["id", "name", "description", "teams"],
-    limit=10
+    team_ids=["TEAM_123"], include=["id", "name", "description", "teams"], limit=10
 )
 
 # Get details for a specific service with only certain fields
@@ -964,9 +969,7 @@ get_teams(include=["id", "name", "type"])
 
 # Get teams with specific fields and filters combined
 get_teams(
-    query="engineering",
-    include=["id", "name", "description", "parent"],
-    limit=10
+    query="engineering", include=["id", "name", "description", "parent"], limit=10
 )
 
 # Get details for a specific team with only certain fields
@@ -1050,11 +1053,7 @@ get_users(user_id="USER_123")
 get_users(include=["id", "name", "email"])
 
 # Get users with specific fields and filters combined
-get_users(
-    team_ids=["TEAM_123"],
-    include=["id", "name", "email", "teams"],
-    limit=10
-)
+get_users(team_ids=["TEAM_123"], include=["id", "name", "email", "teams"], limit=10)
 
 # Get details for a specific user with only certain fields
 get_users(user_id="USER_123", include=["id", "name", "contact_methods"])

--- a/src/pagerduty_mcp_server/escalation_policies.py
+++ b/src/pagerduty_mcp_server/escalation_policies.py
@@ -1,7 +1,7 @@
 """PagerDuty escalation policy operations."""
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from . import utils
 from .async_utils import DEFAULT_MAX_RESULTS, paginate, safe_execute_async
@@ -19,12 +19,12 @@ Escalation Policies API Helpers
 
 async def list_escalation_policies(
     *,
-    query: Optional[str] = None,
-    user_ids: Optional[List[str]] = None,
-    team_ids: Optional[List[str]] = None,
-    limit: Optional[int] = None,
-    include: Optional[List[str]] = None,
-) -> Dict[str, Any]:
+    query: str | None = None,
+    user_ids: list[str] | None = None,
+    team_ids: list[str] | None = None,
+    limit: int | None = None,
+    include: list[str] | None = None,
+) -> dict[str, Any]:
     """List escalation policies based on the given criteria. Exposed in `get_escalation_policies`.
 
     Args:
@@ -43,7 +43,7 @@ async def list_escalation_policies(
 
     pd_client = create_client()
 
-    params: Dict[str, Any] = {}
+    params: dict[str, Any] = {}
     if query:
         params["query"] = query
     if user_ids:
@@ -67,8 +67,8 @@ async def list_escalation_policies(
 
 
 async def show_escalation_policy(
-    *, policy_id: str, include: Optional[List[str]] = None
-) -> Dict[str, Any]:
+    *, policy_id: str, include: list[str] | None = None
+) -> dict[str, Any]:
     """Get detailed information about a given escalation policy. Exposed in `get_escalation_policies`.
 
     Args:
@@ -117,7 +117,7 @@ Escalation Policy Helpers
 """
 
 
-async def fetch_escalation_policy_ids(*, user_id: Optional[str] = None) -> List[str]:
+async def fetch_escalation_policy_ids(*, user_id: str | None = None) -> list[str]:
     """Get the escalation policy IDs for a user. Internal helper function.
 
     Args:

--- a/src/pagerduty_mcp_server/incidents.py
+++ b/src/pagerduty_mcp_server/incidents.py
@@ -3,7 +3,7 @@
 import logging
 import os
 import re
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from . import utils
 from .async_utils import DEFAULT_MAX_RESULTS, paginate, safe_execute_async
@@ -31,15 +31,15 @@ Incidents API Helpers
 
 async def list_incidents(
     *,
-    service_ids: Optional[List[str]] = None,
-    team_ids: Optional[List[str]] = None,
-    statuses: Optional[List[str]] = None,
-    urgencies: Optional[List[str]] = None,
-    since: Optional[str] = None,
-    until: Optional[str] = None,
-    limit: Optional[int] = None,
-    include: Optional[List[str]] = None,
-) -> Dict[str, Any]:
+    service_ids: list[str] | None = None,
+    team_ids: list[str] | None = None,
+    statuses: list[str] | None = None,
+    urgencies: list[str] | None = None,
+    since: str | None = None,
+    until: str | None = None,
+    limit: int | None = None,
+    include: list[str] | None = None,
+) -> dict[str, Any]:
     """List PagerDuty incidents based on specified filters. Exposed in `get_incidents`.
 
     Args:
@@ -86,7 +86,7 @@ async def list_incidents(
                 f"Invalid urgency values: {invalid_urgencies}. Valid values are: {VALID_URGENCIES}"
             )
 
-    params: Dict[str, Any] = {"statuses": statuses, "urgencies": urgencies}
+    params: dict[str, Any] = {"statuses": statuses, "urgencies": urgencies}
     if service_ids:
         params["service_ids"] = service_ids
     if team_ids:
@@ -121,11 +121,11 @@ async def list_incidents(
 async def show_incident(
     *,
     incident_id: str,
-    include_past_incidents: Optional[bool] = False,
-    include_related_incidents: Optional[bool] = False,
-    include_notes: Optional[bool] = False,
-    include: Optional[List[str]] = None,
-) -> Dict[str, Any]:
+    include_past_incidents: bool | None = False,
+    include_related_incidents: bool | None = False,
+    include_notes: bool | None = False,
+    include: list[str] | None = None,
+) -> dict[str, Any]:
     """Get detailed information about a given incident. Exposed as MCP server tool.
 
     Args:
@@ -274,8 +274,8 @@ async def update_incident_status(
     *,
     incident_id: str,
     status: str,
-    include: Optional[List[str]] = None,
-) -> Dict[str, Any]:
+    include: list[str] | None = None,
+) -> dict[str, Any]:
     """Update the status of a PagerDuty incident (acknowledge or resolve).
 
     Args:
@@ -342,7 +342,7 @@ async def create_incident_note(
     *,
     incident_id: str,
     content: str,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Add a note to a PagerDuty incident.
 
     Args:
@@ -404,7 +404,7 @@ Incidents Private Helpers
 """
 
 
-async def _list_past_incidents(*, incident_id: str) -> Dict[str, Any]:
+async def _list_past_incidents(*, incident_id: str) -> dict[str, Any]:
     """List incidents from the past 6 months that are similar to the input incident, and were generated on the same service as the parent incident.
 
     Args:
@@ -459,7 +459,7 @@ async def _list_past_incidents(*, incident_id: str) -> Dict[str, Any]:
         utils.handle_api_error(e)
 
 
-async def _list_related_incidents(*, incident_id: str) -> Dict[str, Any]:
+async def _list_related_incidents(*, incident_id: str) -> dict[str, Any]:
     """List the 20 most recent related incidents that are impacting other services and responders.
 
     Args:
@@ -519,7 +519,7 @@ async def _list_related_incidents(*, incident_id: str) -> Dict[str, Any]:
         utils.handle_api_error(e)
 
 
-async def _list_notes(*, incident_id: str) -> Dict[str, Any]:
+async def _list_notes(*, incident_id: str) -> dict[str, Any]:
     """List notes for a PagerDuty incident. Exposed as MCP server tool.
 
     Args:
@@ -565,7 +565,7 @@ async def _list_notes(*, incident_id: str) -> Dict[str, Any]:
         utils.handle_api_error(e)
 
 
-def _count_incident_statuses(incidents: List[Dict[str, Any]]) -> Dict[str, int]:
+def _count_incident_statuses(incidents: list[dict[str, Any]]) -> dict[str, int]:
     """Count incidents by status. Internal helper function.
 
     Args:
@@ -574,7 +574,7 @@ def _count_incident_statuses(incidents: List[Dict[str, Any]]) -> Dict[str, int]:
     Returns:
         Dict[str, int]: Dictionary mapping status to count
     """
-    status_counts: Dict[str, int] = {}
+    status_counts: dict[str, int] = {}
     for incident in incidents:
         status = incident.get("status")
         if status in VALID_STATUSES:
@@ -582,7 +582,7 @@ def _count_incident_statuses(incidents: List[Dict[str, Any]]) -> Dict[str, int]:
     return status_counts
 
 
-def _count_autoresolved_incidents(incidents: List[Dict[str, Any]]) -> int:
+def _count_autoresolved_incidents(incidents: list[dict[str, Any]]) -> int:
     """Count incidents that were auto-resolved. Internal helper function.
 
     Args:
@@ -602,7 +602,7 @@ def _count_autoresolved_incidents(incidents: List[Dict[str, Any]]) -> int:
     )
 
 
-def _count_no_data_incidents(incidents: List[Dict[str, Any]]) -> int:
+def _count_no_data_incidents(incidents: list[dict[str, Any]]) -> int:
     """Count incidents that are "no data" incidents. Internal helper function.
 
     Args:
@@ -616,7 +616,7 @@ def _count_no_data_incidents(incidents: List[Dict[str, Any]]) -> int:
     )
 
 
-def _calculate_incident_metadata(incidents: List[Dict[str, Any]]) -> Dict[str, Any]:
+def _calculate_incident_metadata(incidents: list[dict[str, Any]]) -> dict[str, Any]:
     """Calculate additional metadata for incidents including status counts and autoresolve count. Internal helper function.
 
     Args:

--- a/src/pagerduty_mcp_server/models/__init__.py
+++ b/src/pagerduty_mcp_server/models/__init__.py
@@ -11,16 +11,16 @@ from .team import Team
 from .user import User
 
 __all__ = [
-    "PagerDutyBaseModel",
-    "Reference",
-    "TypedReference",
-    "IdOnly",
     "EscalationPolicy",
+    "IdOnly",
     "Incident",
     "Note",
     "Oncall",
+    "PagerDutyBaseModel",
+    "Reference",
     "Schedule",
     "Service",
     "Team",
+    "TypedReference",
     "User",
 ]

--- a/src/pagerduty_mcp_server/models/common.py
+++ b/src/pagerduty_mcp_server/models/common.py
@@ -1,6 +1,6 @@
 """Common Pydantic models for PagerDuty resources."""
 
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -12,9 +12,7 @@ class PagerDutyBaseModel(BaseModel):
         use_enum_values=True,
     )
 
-    def to_clean_dict(
-        self, include_fields: Optional[List[str]] = None
-    ) -> Dict[str, Any]:
+    def to_clean_dict(self, include_fields: list[str] | None = None) -> dict[str, Any]:
         """Serialize to dictionary with empty fields excluded, optionally filtering to specific fields.
 
         Args:
@@ -52,19 +50,17 @@ class Reference(PagerDutyBaseModel):
 
     # Essential fields for MCP responses
     id: str
-    summary: Optional[str] = None
+    summary: str | None = None
 
     # API fields excluded from MCP responses for size optimization:
     # - type: str (e.g., "user_reference", "team_reference")
     # - self: str (API URL for this resource)
     # - html_url: str (Web UI URL for this resource)
-    type: Optional[str] = Field(
+    type: str | None = Field(
         None, exclude=True, description="Excluded: API resource type"
     )
-    self: Optional[str] = Field(None, exclude=True, description="Excluded: API URL")
-    html_url: Optional[str] = Field(
-        None, exclude=True, description="Excluded: Web UI URL"
-    )
+    self: str | None = Field(None, exclude=True, description="Excluded: API URL")
+    html_url: str | None = Field(None, exclude=True, description="Excluded: Web UI URL")
 
 
 class TypedReference(Reference):
@@ -75,7 +71,7 @@ class TypedReference(Reference):
     """
 
     # Override to include type in responses for this specific use case
-    type: Optional[str] = Field(
+    type: str | None = Field(
         None, exclude=False, description="Included: Type of referenced resource"
     )
 
@@ -95,13 +91,11 @@ class IdOnly(PagerDutyBaseModel):
     # - summary: str (Human-readable name)
     # - self: str (API URL for this resource)
     # - html_url: str (Web UI URL for this resource)
-    type: Optional[str] = Field(
+    type: str | None = Field(
         None, exclude=True, description="Excluded: API resource type"
     )
-    summary: Optional[str] = Field(
+    summary: str | None = Field(
         None, exclude=True, description="Excluded: Human-readable name"
     )
-    self: Optional[str] = Field(None, exclude=True, description="Excluded: API URL")
-    html_url: Optional[str] = Field(
-        None, exclude=True, description="Excluded: Web UI URL"
-    )
+    self: str | None = Field(None, exclude=True, description="Excluded: API URL")
+    html_url: str | None = Field(None, exclude=True, description="Excluded: Web UI URL")

--- a/src/pagerduty_mcp_server/models/escalation_policy.py
+++ b/src/pagerduty_mcp_server/models/escalation_policy.py
@@ -1,7 +1,5 @@
 """Pydantic models for PagerDuty Escalation Policies."""
 
-from typing import List, Optional
-
 from pydantic import Field
 
 from .common import IdOnly, PagerDutyBaseModel, Reference, TypedReference
@@ -27,7 +25,7 @@ class EscalationRule(PagerDutyBaseModel):
     escalation_delay_in_minutes: int
 
     # Collections - present but can be empty
-    targets: List[EscalationRuleTarget] = []
+    targets: list[EscalationRuleTarget] = []
 
     # API fields excluded from MCP responses for size optimization:
     # Note: Currently no additional fields are excluded at the escalation rule level,
@@ -47,31 +45,29 @@ class EscalationPolicy(PagerDutyBaseModel):
     name: str
 
     # Optional fields included in MCP responses
-    description: Optional[str] = None
+    description: str | None = None
 
     # Collections - present but can be empty
-    escalation_rules: List[EscalationRule] = []
-    services: List[IdOnly] = []
-    teams: List[Reference] = []
+    escalation_rules: list[EscalationRule] = []
+    services: list[IdOnly] = []
+    teams: list[Reference] = []
 
     # API fields excluded from MCP responses for size optimization:
     # These fields are available in the PagerDuty API but excluded to reduce response size
-    type: Optional[str] = Field(
+    type: str | None = Field(
         None, exclude=True, description="Excluded: Always 'escalation_policy'"
     )
-    summary: Optional[str] = Field(
+    summary: str | None = Field(
         None, exclude=True, description="Excluded: Usually same as name"
     )
-    self: Optional[str] = Field(None, exclude=True, description="Excluded: API URL")
-    html_url: Optional[str] = Field(
-        None, exclude=True, description="Excluded: Web UI URL"
-    )
-    num_loops: Optional[int] = Field(
+    self: str | None = Field(None, exclude=True, description="Excluded: API URL")
+    html_url: str | None = Field(None, exclude=True, description="Excluded: Web UI URL")
+    num_loops: int | None = Field(
         None, exclude=True, description="Excluded: Number of escalation loops"
     )
-    on_call_handoff_notifications: Optional[str] = Field(
+    on_call_handoff_notifications: str | None = Field(
         None, exclude=True, description="Excluded: Handoff notification setting"
     )
-    privilege: Optional[str] = Field(
+    privilege: str | None = Field(
         None, exclude=True, description="Excluded: Permission level (usually null)"
     )

--- a/src/pagerduty_mcp_server/models/incident.py
+++ b/src/pagerduty_mcp_server/models/incident.py
@@ -1,6 +1,6 @@
 """Pydantic models for PagerDuty Incidents."""
 
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from pydantic import Field, model_validator
 
@@ -33,81 +33,79 @@ class Incident(PagerDutyBaseModel):
     id: str
 
     # Core fields - present in full API responses but may be missing in simplified contexts
-    incident_number: Optional[int] = None
-    title: Optional[str] = None
-    status: Optional[str] = None
-    urgency: Optional[str] = None
-    created_at: Optional[str] = None
-    updated_at: Optional[str] = None
-    summary: Optional[str] = None
-    description: Optional[str] = None
-    last_status_change_at: Optional[str] = None
+    incident_number: int | None = None
+    title: str | None = None
+    status: str | None = None
+    urgency: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    summary: str | None = None
+    description: str | None = None
+    last_status_change_at: str | None = None
 
     # Optional fields - can be None in API responses
-    resolved_at: Optional[str] = None
-    alert_counts: Optional[Dict[str, Any]] = None
-    body_details: Optional[Dict[str, Any]] = None
-    client_url: Optional[str] = None
+    resolved_at: str | None = None
+    alert_counts: dict[str, Any] | None = None
+    body_details: dict[str, Any] | None = None
+    client_url: str | None = None
 
     # References - can be None
-    service: Optional[IdOnly] = None
-    escalation_policy: Optional[Reference] = None
-    last_status_change_by: Optional[Reference] = None
+    service: IdOnly | None = None
+    escalation_policy: Reference | None = None
+    last_status_change_by: Reference | None = None
 
     # Collections - present but can be empty
-    assignments: List[AssignmentItem] = []
-    acknowledgements: List[AcknowledgementItem] = []
-    teams: List[Reference] = []
+    assignments: list[AssignmentItem] = []
+    acknowledgements: list[AcknowledgementItem] = []
+    teams: list[Reference] = []
 
     # Raw body field for processing
-    body: Optional[Dict[str, Any]] = None
+    body: dict[str, Any] | None = None
 
     # API fields excluded from MCP responses for size optimization:
     # These fields are available in the PagerDuty API but excluded to reduce response size
-    type: Optional[str] = Field(
+    type: str | None = Field(
         None, exclude=True, description="Excluded: Always 'incident'"
     )
-    html_url: Optional[str] = Field(
-        None, exclude=True, description="Excluded: Web UI URL"
-    )
-    self: Optional[str] = Field(None, exclude=True, description="Excluded: API URL")
-    incident_key: Optional[str] = Field(
+    html_url: str | None = Field(None, exclude=True, description="Excluded: Web UI URL")
+    self: str | None = Field(None, exclude=True, description="Excluded: API URL")
+    incident_key: str | None = Field(
         None, exclude=True, description="Excluded: External incident key"
     )
-    assigned_via: Optional[str] = Field(
+    assigned_via: str | None = Field(
         None, exclude=True, description="Excluded: How incident was assigned"
     )
-    incident_type: Optional[Dict[str, Any]] = Field(
+    incident_type: dict[str, Any] | None = Field(
         None, exclude=True, description="Excluded: Incident type metadata"
     )
-    is_mergeable: Optional[bool] = Field(
+    is_mergeable: bool | None = Field(
         None, exclude=True, description="Excluded: Whether incident can be merged"
     )
-    pending_actions: Optional[List[Dict[str, Any]]] = Field(
+    pending_actions: list[dict[str, Any]] | None = Field(
         None, exclude=True, description="Excluded: Pending actions list"
     )
-    priority: Optional[Dict[str, Any]] = Field(
+    priority: dict[str, Any] | None = Field(
         None, exclude=True, description="Excluded: Priority metadata"
     )
-    resolve_reason: Optional[str] = Field(
+    resolve_reason: str | None = Field(
         None, exclude=True, description="Excluded: Reason for resolution"
     )
-    responder_requests: Optional[List[Dict[str, Any]]] = Field(
+    responder_requests: list[dict[str, Any]] | None = Field(
         None, exclude=True, description="Excluded: Responder requests list"
     )
-    subscriber_requests: Optional[List[Dict[str, Any]]] = Field(
+    subscriber_requests: list[dict[str, Any]] | None = Field(
         None, exclude=True, description="Excluded: Subscriber requests list"
     )
-    alert_grouping: Optional[Dict[str, Any]] = Field(
+    alert_grouping: dict[str, Any] | None = Field(
         None, exclude=True, description="Excluded: Alert grouping configuration"
     )
-    basic_alert_grouping: Optional[Dict[str, Any]] = Field(
+    basic_alert_grouping: dict[str, Any] | None = Field(
         None, exclude=True, description="Excluded: Basic alert grouping configuration"
     )
-    incidents_responders: Optional[List[Dict[str, Any]]] = Field(
+    incidents_responders: list[dict[str, Any]] | None = Field(
         None, exclude=True, description="Excluded: Incident responders list"
     )
-    first_trigger_log_entry: Optional[Dict[str, Any]] = Field(
+    first_trigger_log_entry: dict[str, Any] | None = Field(
         None, exclude=True, description="Excluded: First trigger log entry reference"
     )
 
@@ -124,7 +122,7 @@ class Incident(PagerDutyBaseModel):
                 if isinstance(raw_body_details, dict) and raw_body_details:
                     # Get all keys except 'title'
                     keys_for_body_details = [
-                        k for k in raw_body_details.keys() if k != "title"
+                        k for k in raw_body_details if k != "title"
                     ]
 
                     # Extract only the specified keys

--- a/src/pagerduty_mcp_server/models/note.py
+++ b/src/pagerduty_mcp_server/models/note.py
@@ -1,7 +1,5 @@
 """Pydantic models for PagerDuty Notes."""
 
-from typing import Optional
-
 from pydantic import ConfigDict, Field
 
 from .common import PagerDutyBaseModel
@@ -13,13 +11,13 @@ class NoteUser(PagerDutyBaseModel):
     model_config = ConfigDict(populate_by_name=True, use_enum_values=True)
 
     id: str
-    name: Optional[str] = Field(None, alias="summary", serialization_alias="name")
+    name: str | None = Field(None, alias="summary", serialization_alias="name")
 
 
 class NoteChannel(PagerDutyBaseModel):
     """A channel where a note was created."""
 
-    summary: Optional[str] = None
+    summary: str | None = None
 
 
 class Note(PagerDutyBaseModel):
@@ -29,7 +27,7 @@ class Note(PagerDutyBaseModel):
     id: str
 
     # Core fields - present in full API responses but may be missing in simplified contexts
-    content: Optional[str] = None
-    created_at: Optional[str] = None
-    user: Optional[NoteUser] = None
-    channel: Optional[NoteChannel] = None
+    content: str | None = None
+    created_at: str | None = None
+    user: NoteUser | None = None
+    channel: NoteChannel | None = None

--- a/src/pagerduty_mcp_server/models/oncall.py
+++ b/src/pagerduty_mcp_server/models/oncall.py
@@ -1,7 +1,5 @@
 """Pydantic models for PagerDuty On-Calls."""
 
-from typing import Optional
-
 from .common import PagerDutyBaseModel, Reference
 
 
@@ -9,9 +7,9 @@ class Oncall(PagerDutyBaseModel):
     """A Pydantic model for a PagerDuty On-Call."""
 
     # All fields optional to handle various API response contexts
-    user: Optional[Reference] = None
-    schedule: Optional[Reference] = None
-    escalation_policy: Optional[Reference] = None
-    escalation_level: Optional[int] = None
-    start: Optional[str] = None
-    end: Optional[str] = None
+    user: Reference | None = None
+    schedule: Reference | None = None
+    escalation_policy: Reference | None = None
+    escalation_level: int | None = None
+    start: str | None = None
+    end: str | None = None

--- a/src/pagerduty_mcp_server/models/schedule.py
+++ b/src/pagerduty_mcp_server/models/schedule.py
@@ -1,6 +1,6 @@
 """Pydantic models for PagerDuty Schedules."""
 
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from pydantic import Field, field_validator
 
@@ -11,7 +11,7 @@ class ScheduleLayerUser(PagerDutyBaseModel):
     """A user in a schedule layer."""
 
     id: str
-    summary: Optional[str] = None
+    summary: str | None = None
 
 
 class ScheduleLayer(PagerDutyBaseModel):
@@ -21,12 +21,12 @@ class ScheduleLayer(PagerDutyBaseModel):
     id: str
 
     # Core fields - present in full API responses but may be missing in simplified contexts
-    name: Optional[str] = None
-    start: Optional[str] = None
-    end: Optional[str] = None
+    name: str | None = None
+    start: str | None = None
+    end: str | None = None
 
     # Collections - present but can be empty
-    users: List[ScheduleLayerUser] = []
+    users: list[ScheduleLayerUser] = []
 
     @field_validator("users", mode="before")
     @classmethod
@@ -65,33 +65,31 @@ class Schedule(PagerDutyBaseModel):
     id: str
 
     # Core fields - present in full API responses but may be missing in simplified contexts
-    name: Optional[str] = None
-    summary: Optional[str] = None
-    time_zone: Optional[str] = None
+    name: str | None = None
+    summary: str | None = None
+    time_zone: str | None = None
 
     # Optional fields - can be None in API responses
-    description: Optional[str] = None
+    description: str | None = None
 
     # Collections - present but can be empty
-    escalation_policies: List[Reference] = []
-    teams: List[Reference] = []
-    schedule_layers: List[ScheduleLayer] = []
+    escalation_policies: list[Reference] = []
+    teams: list[Reference] = []
+    schedule_layers: list[ScheduleLayer] = []
 
     # API fields excluded from MCP responses for size optimization:
     # These fields are available in the PagerDuty API but excluded to reduce response size
-    type: Optional[str] = Field(
+    type: str | None = Field(
         None, exclude=True, description="Excluded: Always 'schedule'"
     )
-    html_url: Optional[str] = Field(
-        None, exclude=True, description="Excluded: Web UI URL"
-    )
-    self: Optional[str] = Field(None, exclude=True, description="Excluded: API URL")
-    http_cal_url: Optional[str] = Field(
+    html_url: str | None = Field(None, exclude=True, description="Excluded: Web UI URL")
+    self: str | None = Field(None, exclude=True, description="Excluded: API URL")
+    http_cal_url: str | None = Field(
         None, exclude=True, description="Excluded: HTTP calendar URL"
     )
-    final_schedule: Optional[Dict[str, Any]] = Field(
+    final_schedule: dict[str, Any] | None = Field(
         None, exclude=True, description="Excluded: Final schedule configuration"
     )
-    overrides_subschedule: Optional[Dict[str, Any]] = Field(
+    overrides_subschedule: dict[str, Any] | None = Field(
         None, exclude=True, description="Excluded: Override subschedule configuration"
     )

--- a/src/pagerduty_mcp_server/models/service.py
+++ b/src/pagerduty_mcp_server/models/service.py
@@ -1,7 +1,5 @@
 """Pydantic models for PagerDuty Services."""
 
-from typing import List, Optional
-
 from pydantic import Field
 
 from .common import PagerDutyBaseModel, Reference
@@ -19,20 +17,18 @@ class Service(PagerDutyBaseModel):
     id: str
 
     # Core fields - present in full API responses but may be missing in simplified contexts
-    name: Optional[str] = None
-    status: Optional[str] = None
-    created_at: Optional[str] = None
-    updated_at: Optional[str] = None
+    name: str | None = None
+    status: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
 
     # Optional fields - can be None in API responses
-    description: Optional[str] = None
+    description: str | None = None
 
     # Collections - present but can be empty
-    teams: List[Reference] = []
-    integrations: List[Reference] = []
+    teams: list[Reference] = []
+    integrations: list[Reference] = []
 
     # API fields excluded from MCP responses for size optimization:
     # These fields are available in the PagerDuty API but excluded to reduce response size
-    html_url: Optional[str] = Field(
-        None, exclude=True, description="Excluded: Web UI URL"
-    )
+    html_url: str | None = Field(None, exclude=True, description="Excluded: Web UI URL")

--- a/src/pagerduty_mcp_server/models/team.py
+++ b/src/pagerduty_mcp_server/models/team.py
@@ -1,7 +1,5 @@
 """Pydantic models for PagerDuty Teams."""
 
-from typing import Optional
-
 from pydantic import Field
 
 from .common import PagerDutyBaseModel
@@ -11,7 +9,7 @@ class TeamParent(PagerDutyBaseModel):
     """A parent team reference."""
 
     id: str
-    type: Optional[str] = None
+    type: str | None = None
 
 
 class Team(PagerDutyBaseModel):
@@ -26,24 +24,20 @@ class Team(PagerDutyBaseModel):
     id: str
 
     # Core fields - present in full API responses but may be missing in simplified contexts
-    name: Optional[str] = None
+    name: str | None = None
 
     # Optional fields - can be None in API responses
-    description: Optional[str] = None
-    parent: Optional[TeamParent] = None
+    description: str | None = None
+    parent: TeamParent | None = None
 
     # API fields excluded from MCP responses for size optimization:
     # These fields are available in the PagerDuty API but excluded to reduce response size
-    type: Optional[str] = Field(
-        None, exclude=True, description="Excluded: Always 'team'"
-    )
-    summary: Optional[str] = Field(
+    type: str | None = Field(None, exclude=True, description="Excluded: Always 'team'")
+    summary: str | None = Field(
         None, exclude=True, description="Excluded: Usually same as name"
     )
-    self: Optional[str] = Field(None, exclude=True, description="Excluded: API URL")
-    html_url: Optional[str] = Field(
-        None, exclude=True, description="Excluded: Web UI URL"
-    )
-    default_role: Optional[str] = Field(
+    self: str | None = Field(None, exclude=True, description="Excluded: API URL")
+    html_url: str | None = Field(None, exclude=True, description="Excluded: Web UI URL")
+    default_role: str | None = Field(
         None, exclude=True, description="Excluded: Default member role"
     )

--- a/src/pagerduty_mcp_server/models/user.py
+++ b/src/pagerduty_mcp_server/models/user.py
@@ -1,6 +1,6 @@
 """Pydantic models for PagerDuty Users."""
 
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from pydantic import Field
 
@@ -15,13 +15,11 @@ class NotificationRule(PagerDutyBaseModel):
 
     # API fields excluded from MCP responses for size optimization:
     # These fields are available in the PagerDuty API but excluded to reduce response size
-    summary: Optional[str] = Field(
+    summary: str | None = Field(
         None, exclude=True, description="Excluded: Human-readable summary"
     )
-    self: Optional[str] = Field(None, exclude=True, description="Excluded: API URL")
-    html_url: Optional[str] = Field(
-        None, exclude=True, description="Excluded: Web UI URL"
-    )
+    self: str | None = Field(None, exclude=True, description="Excluded: API URL")
+    html_url: str | None = Field(None, exclude=True, description="Excluded: Web UI URL")
 
 
 class User(PagerDutyBaseModel):
@@ -36,51 +34,49 @@ class User(PagerDutyBaseModel):
     id: str
 
     # Core fields - present in full API responses but may be missing in simplified contexts
-    name: Optional[str] = None
-    email: Optional[str] = None
-    type: Optional[str] = None
+    name: str | None = None
+    email: str | None = None
+    type: str | None = None
 
     # Optional fields - can be None in API responses
-    description: Optional[str] = None
+    description: str | None = None
 
     # Collections - present but can be empty
-    teams: List[TypedReference] = []
-    contact_methods: List[TypedReference] = []
-    notification_rules: List[NotificationRule] = []
+    teams: list[TypedReference] = []
+    contact_methods: list[TypedReference] = []
+    notification_rules: list[NotificationRule] = []
 
     # API fields excluded from MCP responses for size optimization:
     # These fields are available in the PagerDuty API but excluded to reduce response size
-    time_zone: Optional[str] = Field(
+    time_zone: str | None = Field(
         None, exclude=True, description="Excluded: User's time zone"
     )
-    color: Optional[str] = Field(
+    color: str | None = Field(
         None, exclude=True, description="Excluded: User's color preference"
     )
-    avatar_url: Optional[str] = Field(
+    avatar_url: str | None = Field(
         None, exclude=True, description="Excluded: User's avatar URL"
     )
-    billed: Optional[bool] = Field(
+    billed: bool | None = Field(
         None, exclude=True, description="Excluded: Whether user is billed"
     )
-    role: Optional[str] = Field(
+    role: str | None = Field(
         None, exclude=True, description="Excluded: User's account role"
     )
-    invitation_sent: Optional[bool] = Field(
+    invitation_sent: bool | None = Field(
         None, exclude=True, description="Excluded: Whether invitation was sent"
     )
-    job_title: Optional[str] = Field(
+    job_title: str | None = Field(
         None, exclude=True, description="Excluded: User's job title"
     )
-    coordinated_incidents: Optional[List[Dict[str, Any]]] = Field(
+    coordinated_incidents: list[dict[str, Any]] | None = Field(
         None, exclude=True, description="Excluded: Coordinated incidents list"
     )
-    locale: Optional[str] = Field(
+    locale: str | None = Field(
         None, exclude=True, description="Excluded: User's locale preference"
     )
-    summary: Optional[str] = Field(
+    summary: str | None = Field(
         None, exclude=True, description="Excluded: Usually same as name"
     )
-    self: Optional[str] = Field(None, exclude=True, description="Excluded: API URL")
-    html_url: Optional[str] = Field(
-        None, exclude=True, description="Excluded: Web UI URL"
-    )
+    self: str | None = Field(None, exclude=True, description="Excluded: API URL")
+    html_url: str | None = Field(None, exclude=True, description="Excluded: Web UI URL")

--- a/src/pagerduty_mcp_server/oncalls.py
+++ b/src/pagerduty_mcp_server/oncalls.py
@@ -1,7 +1,7 @@
 """PagerDuty on-call operations."""
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from . import utils
 from .async_utils import DEFAULT_MAX_RESULTS, paginate
@@ -19,15 +19,15 @@ On-Calls API Helpers
 
 async def list_oncalls(
     *,
-    schedule_ids: Optional[List[str]] = None,
-    user_ids: Optional[List[str]] = None,
-    escalation_policy_ids: Optional[List[str]] = None,
-    since: Optional[str] = None,
-    until: Optional[str] = None,
-    limit: Optional[int] = None,
-    earliest: Optional[bool] = None,
-    include: Optional[List[str]] = None,
-) -> Dict[str, Any]:
+    schedule_ids: list[str] | None = None,
+    user_ids: list[str] | None = None,
+    escalation_policy_ids: list[str] | None = None,
+    since: str | None = None,
+    until: str | None = None,
+    limit: int | None = None,
+    earliest: bool | None = None,
+    include: list[str] | None = None,
+) -> dict[str, Any]:
     """List the on-call entries during a given time range.
     An oncall-entry contains the user that is on-call for the given schedule, escalation policy, or time range and also includes the schedule and escalation policy that the user is on-call for. Exposed in `get_oncalls`.
 
@@ -51,7 +51,7 @@ async def list_oncalls(
 
     pd_client = create_client()
 
-    params: Dict[str, Any] = {}
+    params: dict[str, Any] = {}
     if schedule_ids:
         params["schedule_ids[]"] = schedule_ids
     if user_ids:

--- a/src/pagerduty_mcp_server/schedules.py
+++ b/src/pagerduty_mcp_server/schedules.py
@@ -1,7 +1,7 @@
 """PagerDuty schedule operations."""
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from . import utils
 from .async_utils import DEFAULT_MAX_RESULTS, paginate, safe_execute_async
@@ -20,10 +20,10 @@ Schedules API Helpers
 
 async def list_schedules(
     *,
-    query: Optional[str] = None,
-    limit: Optional[int] = None,
-    include: Optional[List[str]] = None,
-) -> Dict[str, Any]:
+    query: str | None = None,
+    limit: int | None = None,
+    include: list[str] | None = None,
+) -> dict[str, Any]:
     """List existing PagerDuty schedules. Returns all schedules that match the given search criteria. Exposed in `get_schedules`.
 
     Args:
@@ -63,10 +63,10 @@ async def list_schedules(
 async def show_schedule(
     *,
     schedule_id: str,
-    since: Optional[str] = None,
-    until: Optional[str] = None,
-    include: Optional[List[str]] = None,
-) -> Dict[str, Any]:
+    since: str | None = None,
+    until: str | None = None,
+    include: list[str] | None = None,
+) -> dict[str, Any]:
     """Get detailed information about a given schedule, including its configuration and current state. Exposed in `get_schedules`.
 
     Args:
@@ -123,10 +123,10 @@ async def show_schedule(
 async def list_users_oncall(
     *,
     schedule_id: str,
-    since: Optional[str] = None,
-    until: Optional[str] = None,
-    include: Optional[List[str]] = None,
-) -> Dict[str, Any]:
+    since: str | None = None,
+    until: str | None = None,
+    include: list[str] | None = None,
+) -> dict[str, Any]:
     """List the users on call for a given schedule during the specified time range. Returns a list of users who are or will be on call during the specified period. Exposed as MCP server tool.
 
     Args:

--- a/src/pagerduty_mcp_server/server.py
+++ b/src/pagerduty_mcp_server/server.py
@@ -1,9 +1,10 @@
 """PagerDuty MCP Server main module."""
 
+from collections.abc import Awaitable, Callable
 from functools import wraps
 from importlib.metadata import version
 from pathlib import Path
-from typing import Any, Awaitable, Callable, Dict, List, Optional
+from typing import Any
 
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
@@ -40,12 +41,12 @@ mcp = FastMCP(
 
 
 def tool_error_boundary(
-    func: Callable[..., Awaitable[Dict[str, Any]]],
-) -> Callable[..., Awaitable[Dict[str, Any]]]:
+    func: Callable[..., Awaitable[dict[str, Any]]],
+) -> Callable[..., Awaitable[dict[str, Any]]]:
     """Convert common tool failures into ToolError so FastMCP sets isError=true."""
 
     @wraps(func)
-    async def wrapper(*args, **kwargs) -> Dict[str, Any]:
+    async def wrapper(*args, **kwargs) -> dict[str, Any]:
         try:
             return await func(*args, **kwargs)
         except ToolError:
@@ -82,14 +83,14 @@ Escalation Policies Tools
 @validation.validate_include_parameter(EscalationPolicy)
 async def get_escalation_policies(
     *,
-    policy_id: Optional[str] = None,
+    policy_id: str | None = None,
     current_user_context: bool = True,
-    query: Optional[str] = None,
-    user_ids: Optional[List[str]] = None,
-    team_ids: Optional[List[str]] = None,
-    limit: Optional[int] = None,
-    include: Optional[List[str]] = None,
-) -> Dict[str, Any]:
+    query: str | None = None,
+    user_ids: list[str] | None = None,
+    team_ids: list[str] | None = None,
+    limit: int | None = None,
+    include: list[str] | None = None,
+) -> dict[str, Any]:
     """Get PagerDuty escalation policies by filters or get details for a specific policy ID.
 
     Args:
@@ -151,20 +152,20 @@ Incidents Tools
 )
 async def get_incidents(
     *,
-    incident_id: Optional[str] = None,
+    incident_id: str | None = None,
     current_user_context: bool = True,
-    service_ids: Optional[List[str]] = None,
-    team_ids: Optional[List[str]] = None,
-    statuses: Optional[List[str]] = None,
-    urgencies: Optional[List[str]] = None,
-    since: Optional[str] = None,
-    until: Optional[str] = None,
-    limit: Optional[int] = None,
-    include_past_incidents: Optional[bool] = False,
-    include_related_incidents: Optional[bool] = False,
-    include_notes: Optional[bool] = False,
-    include: Optional[List[str]] = None,
-) -> Dict[str, Any]:
+    service_ids: list[str] | None = None,
+    team_ids: list[str] | None = None,
+    statuses: list[str] | None = None,
+    urgencies: list[str] | None = None,
+    since: str | None = None,
+    until: str | None = None,
+    limit: int | None = None,
+    include_past_incidents: bool | None = False,
+    include_related_incidents: bool | None = False,
+    include_notes: bool | None = False,
+    include: list[str] | None = None,
+) -> dict[str, Any]:
     """Get PagerDuty incidents by filters or get details for a specific incident ID or number.
 
     Args:
@@ -247,8 +248,8 @@ async def get_incidents(
 async def acknowledge_incident(
     *,
     incident_id: str,
-    include: Optional[List[str]] = None,
-) -> Dict[str, Any]:
+    include: list[str] | None = None,
+) -> dict[str, Any]:
     """Acknowledge a PagerDuty incident. This signals that someone is actively working on the incident.
 
     Args:
@@ -268,8 +269,8 @@ async def acknowledge_incident(
 async def resolve_incident(
     *,
     incident_id: str,
-    include: Optional[List[str]] = None,
-) -> Dict[str, Any]:
+    include: list[str] | None = None,
+) -> dict[str, Any]:
     """Resolve a PagerDuty incident. This marks the incident as resolved and stops any further escalations.
 
     Args:
@@ -289,7 +290,7 @@ async def add_incident_note(
     *,
     incident_id: str,
     content: str,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Add a note to a PagerDuty incident. Notes are used to record additional context, investigation progress, or resolution details.
 
     Args:
@@ -313,15 +314,15 @@ Oncalls Tools
 async def get_oncalls(
     *,
     current_user_context: bool = True,
-    schedule_ids: Optional[List[str]] = None,
-    user_ids: Optional[List[str]] = None,
-    escalation_policy_ids: Optional[List[str]] = None,
-    since: Optional[str] = None,
-    until: Optional[str] = None,
-    limit: Optional[int] = None,
-    earliest: Optional[bool] = None,
-    include: Optional[List[str]] = None,
-) -> Dict[str, Any]:
+    schedule_ids: list[str] | None = None,
+    user_ids: list[str] | None = None,
+    escalation_policy_ids: list[str] | None = None,
+    since: str | None = None,
+    until: str | None = None,
+    limit: int | None = None,
+    earliest: bool | None = None,
+    include: list[str] | None = None,
+) -> dict[str, Any]:
     """List on-call entries for schedules, policies, or time ranges.
 
     Behavior varies by time parameters:
@@ -378,13 +379,13 @@ Schedules Tools
 @validation.validate_include_parameter(Schedule)
 async def get_schedules(
     *,
-    schedule_id: Optional[str] = None,
-    query: Optional[str] = None,
-    limit: Optional[int] = None,
-    since: Optional[str] = None,
-    until: Optional[str] = None,
-    include: Optional[List[str]] = None,
-) -> Dict[str, Any]:
+    schedule_id: str | None = None,
+    query: str | None = None,
+    limit: int | None = None,
+    since: str | None = None,
+    until: str | None = None,
+    include: list[str] | None = None,
+) -> dict[str, Any]:
     """Get PagerDuty schedules by filters or get details for a specific schedule ID.
 
     Args:
@@ -417,10 +418,10 @@ async def get_schedules(
 async def list_users_oncall(
     *,
     schedule_id: str,
-    since: Optional[str] = None,
-    until: Optional[str] = None,
-    include: Optional[List[str]] = None,
-) -> Dict[str, Any]:
+    since: str | None = None,
+    until: str | None = None,
+    include: list[str] | None = None,
+) -> dict[str, Any]:
     """List the users on call for a schedule during the specified time range.
 
     Args:
@@ -447,13 +448,13 @@ Services Tools
 @validation.validate_include_parameter(Service)
 async def get_services(
     *,
-    service_id: Optional[str] = None,
+    service_id: str | None = None,
     current_user_context: bool = True,
-    team_ids: Optional[List[str]] = None,
-    query: Optional[str] = None,
-    limit: Optional[int] = None,
-    include: Optional[List[str]] = None,
-) -> Dict[str, Any]:
+    team_ids: list[str] | None = None,
+    query: str | None = None,
+    limit: int | None = None,
+    include: list[str] | None = None,
+) -> dict[str, Any]:
     """Get PagerDuty services by filters or get details for a specific service ID.
 
     Args:
@@ -502,11 +503,11 @@ Teams Tools
 @validation.validate_include_parameter(Team)
 async def get_teams(
     *,
-    team_id: Optional[str] = None,
-    query: Optional[str] = None,
-    limit: Optional[int] = None,
-    include: Optional[List[str]] = None,
-) -> Dict[str, Any]:
+    team_id: str | None = None,
+    query: str | None = None,
+    limit: int | None = None,
+    include: list[str] | None = None,
+) -> dict[str, Any]:
     """Get PagerDuty teams by filters or get details for a specific team ID.
 
     Args:
@@ -537,13 +538,13 @@ Users Tools
 @validation.validate_include_parameter(User)
 async def get_users(
     *,
-    user_id: Optional[str] = None,
+    user_id: str | None = None,
     current_user_context: bool = True,
-    team_ids: Optional[List[str]] = None,
-    query: Optional[str] = None,
-    limit: Optional[int] = None,
-    include: Optional[List[str]] = None,
-) -> Dict[str, Any]:
+    team_ids: list[str] | None = None,
+    query: str | None = None,
+    limit: int | None = None,
+    include: list[str] | None = None,
+) -> dict[str, Any]:
     """Get PagerDuty users by filters or get details for a specific user ID.
 
     Args:
@@ -584,7 +585,7 @@ async def get_users(
 
 @mcp.tool()
 @tool_error_boundary
-async def build_user_context() -> Dict[str, Any]:
+async def build_user_context() -> dict[str, Any]:
     """Validate and build the current user's context into a dictionary with the following format:
         {
             "user_id": str,

--- a/src/pagerduty_mcp_server/services.py
+++ b/src/pagerduty_mcp_server/services.py
@@ -1,7 +1,7 @@
 """PagerDuty service operations."""
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from . import utils
 from .async_utils import DEFAULT_MAX_RESULTS, paginate, safe_execute_async
@@ -19,11 +19,11 @@ Services API Helpers
 
 async def list_services(
     *,
-    team_ids: Optional[List[str]] = None,
-    query: Optional[str] = None,
-    limit: Optional[int] = None,
-    include: Optional[List[str]] = None,
-) -> Dict[str, Any]:
+    team_ids: list[str] | None = None,
+    query: str | None = None,
+    limit: int | None = None,
+    include: list[str] | None = None,
+) -> dict[str, Any]:
     """List existing PagerDuty services. Exposed as MCP server tool.
 
     Args:
@@ -45,7 +45,7 @@ async def list_services(
     if team_ids is not None and not team_ids:
         raise ValueError("team_ids cannot be an empty list")
 
-    params: Dict[str, Any] = {}
+    params: dict[str, Any] = {}
     if team_ids:
         params["team_ids[]"] = (
             team_ids  # PagerDuty API expects array parameters with [] suffix
@@ -67,8 +67,8 @@ async def list_services(
 
 
 async def show_service(
-    *, service_id: str, include: Optional[List[str]] = None
-) -> Dict[str, Any]:
+    *, service_id: str, include: list[str] | None = None
+) -> dict[str, Any]:
     """Get detailed information about a given service. Exposed as MCP server tool.
 
     Args:
@@ -117,7 +117,7 @@ Services Helpers
 """
 
 
-async def fetch_service_ids(*, team_ids: List[str]) -> List[str]:
+async def fetch_service_ids(*, team_ids: list[str]) -> list[str]:
     """Get the service IDs for a list of team IDs. Internal helper function.
 
     Args:

--- a/src/pagerduty_mcp_server/teams.py
+++ b/src/pagerduty_mcp_server/teams.py
@@ -1,7 +1,7 @@
 """PagerDuty team operations."""
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from . import utils
 from .async_utils import DEFAULT_MAX_RESULTS, paginate, safe_execute_async
@@ -19,10 +19,10 @@ Teams API Helpers
 
 async def list_teams(
     *,
-    query: Optional[str] = None,
-    limit: Optional[int] = None,
-    include: Optional[List[str]] = None,
-) -> Dict[str, Any]:
+    query: str | None = None,
+    limit: int | None = None,
+    include: list[str] | None = None,
+) -> dict[str, Any]:
     """List teams in your PagerDuty account. Exposed as MCP server tool.
 
     Args:
@@ -58,8 +58,8 @@ async def list_teams(
 
 
 async def show_team(
-    *, team_id: str, include: Optional[List[str]] = None
-) -> Dict[str, Any]:
+    *, team_id: str, include: list[str] | None = None
+) -> dict[str, Any]:
     """Get detailed information about a given team. Exposed as MCP server tool.
 
     Args:
@@ -105,7 +105,7 @@ Teams Helpers
 """
 
 
-def fetch_team_ids(*, user: Dict[str, Any]) -> List[str]:
+def fetch_team_ids(*, user: dict[str, Any]) -> list[str]:
     """Get the team IDs for a user. Internal helper function.
 
     Args:

--- a/src/pagerduty_mcp_server/users.py
+++ b/src/pagerduty_mcp_server/users.py
@@ -1,7 +1,7 @@
 """PagerDuty user operations."""
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from . import escalation_policies, services, teams, utils
 from .async_utils import DEFAULT_MAX_RESULTS, paginate, safe_execute_async
@@ -13,7 +13,7 @@ USERS_URL = "/users"
 logger = logging.getLogger(__name__)
 
 
-async def build_user_context() -> Dict[str, Any]:
+async def build_user_context() -> dict[str, Any]:
     """Validate and build the current user's context. Exposed as MCP server tool.
 
     See the "Standard Response Format" section in `tools.md` for the complete standard response structure.
@@ -75,11 +75,11 @@ Users API Helpers
 
 async def list_users(
     *,
-    team_ids: Optional[List[str]] = None,
-    query: Optional[str] = None,
-    limit: Optional[int] = None,
-    include: Optional[List[str]] = None,
-) -> Dict[str, Any]:
+    team_ids: list[str] | None = None,
+    query: str | None = None,
+    limit: int | None = None,
+    include: list[str] | None = None,
+) -> dict[str, Any]:
     """List users in PagerDuty. Exposed as MCP server tool.
 
     Args:
@@ -98,7 +98,7 @@ async def list_users(
 
     pd_client = create_client()
 
-    params: Dict[str, Any] = {}
+    params: dict[str, Any] = {}
 
     if team_ids:
         params["team_ids[]"] = team_ids
@@ -119,8 +119,8 @@ async def list_users(
 
 
 async def show_user(
-    *, user_id: str, include: Optional[List[str]] = None
-) -> Dict[str, Any]:
+    *, user_id: str, include: list[str] | None = None
+) -> dict[str, Any]:
     """Get detailed information about a given user. Exposed as MCP server tool.
 
     Args:
@@ -166,7 +166,7 @@ Users Private Helpers
 """
 
 
-async def _show_current_user() -> Dict[str, Any]:
+async def _show_current_user() -> dict[str, Any]:
     """Get the current user's PagerDuty profile including their teams, contact methods, and notification rules.
 
     Returns:

--- a/src/pagerduty_mcp_server/utils.py
+++ b/src/pagerduty_mcp_server/utils.py
@@ -3,7 +3,7 @@
 import logging
 import sys
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, NoReturn, Optional, Type, Union
+from typing import Any, NoReturn
 
 from . import prompts
 from .errors import PagerDutyError
@@ -26,10 +26,10 @@ Utils public methods
 
 def api_response_handler(
     *,
-    results: Union[Dict[str, Any], List[Dict[str, Any]]],
+    results: dict[str, Any] | list[dict[str, Any]],
     resource_name: str,
-    additional_metadata: Optional[Dict[str, Any]] = None,
-) -> Dict[str, Any]:
+    additional_metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     """Process API response and return a standardized format.
 
     Example response:
@@ -119,7 +119,7 @@ def validate_iso8601_timestamp(timestamp: str, param_name: str) -> None:
         ValidationError: If the timestamp is not a valid ISO8601 format
     """
     try:
-        datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+        datetime.fromisoformat(timestamp)
     except ValueError:
         raise ValidationError(
             f"Invalid ISO8601 timestamp value `{timestamp}` for parameter `{param_name}`. Try using a valid ISO8601 timestamp (for example `2025-02-26T00:00:00Z`)."
@@ -141,8 +141,8 @@ def validate_timestamp_range(since: str, until: str) -> None:
         ValidationError: If the date range is not valid
     """
     if since and until:
-        since_dt = datetime.fromisoformat(since.replace("Z", "+00:00"))
-        until_dt = datetime.fromisoformat(until.replace("Z", "+00:00"))
+        since_dt = datetime.fromisoformat(since)
+        until_dt = datetime.fromisoformat(until)
 
         if since_dt > until_dt:
             raise ValidationError("`since` must be before `until`")
@@ -256,12 +256,12 @@ def count_object_chars(obj: Any) -> int:
 
 
 def parse_list_response(
-    response: List[Dict[str, Any]],
-    model_class: Type[PagerDutyBaseModel],
+    response: list[dict[str, Any]],
+    model_class: type[PagerDutyBaseModel],
     resource_name: str,
-    include: Optional[List[str]] = None,
-    additional_metadata: Optional[Dict[str, Any]] = None,
-) -> Dict[str, Any]:
+    include: list[str] | None = None,
+    additional_metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     """Parse a paginated list response into a standardized API response.
 
     Args:

--- a/src/pagerduty_mcp_server/validation.py
+++ b/src/pagerduty_mcp_server/validation.py
@@ -1,7 +1,6 @@
 import difflib
 import functools
 import logging
-from typing import List, Optional, Type
 
 from .models.common import PagerDutyBaseModel
 
@@ -9,8 +8,8 @@ logger = logging.getLogger(__name__)
 
 
 def validate_include_parameter(
-    model_class: Type[PagerDutyBaseModel],
-    extra_fields: Optional[List[str]] = None,
+    model_class: type[PagerDutyBaseModel],
+    extra_fields: list[str] | None = None,
 ):
     """Decorator to validate that a list of 'include' fields is valid for a given model.
 
@@ -35,10 +34,10 @@ def validate_include_parameter(
 
 
 def validate_include_fields(
-    include: Optional[List[str]],
-    model_class: Type[PagerDutyBaseModel],
-    extra_fields: Optional[List[str]] = None,
-) -> Optional[List[str]]:
+    include: list[str] | None,
+    model_class: type[PagerDutyBaseModel],
+    extra_fields: list[str] | None = None,
+) -> list[str] | None:
     """Validate that a list of fields is valid for a given model.
 
     Args:

--- a/tests/integration/test_client_integration.py
+++ b/tests/integration/test_client_integration.py
@@ -1,8 +1,8 @@
 import pagerduty
 import pytest
-from tests.conftest import skip_if_no_pagerduty_key
 
 from pagerduty_mcp_server.client import create_client
+from tests.conftest import skip_if_no_pagerduty_key
 
 
 @pytest.mark.integration

--- a/tests/integration/test_escalation_policies_integration.py
+++ b/tests/integration/test_escalation_policies_integration.py
@@ -1,7 +1,7 @@
 import pytest
-from tests.conftest import skip_if_no_pagerduty_key
 
 from pagerduty_mcp_server import escalation_policies
+from tests.conftest import skip_if_no_pagerduty_key
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_incidents_integration.py
+++ b/tests/integration/test_incidents_integration.py
@@ -1,9 +1,9 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import pytest
-from tests.conftest import skip_if_no_pagerduty_key
 
 from pagerduty_mcp_server import incidents
+from tests.conftest import skip_if_no_pagerduty_key
 
 
 @pytest.mark.asyncio
@@ -14,8 +14,8 @@ async def test_list_incidents(user_context):
     """Test that incidents are fetched correctly."""
     team_ids = user_context["team_ids"]
 
-    since = (datetime.now() - timedelta(days=1)).isoformat()
-    until = datetime.now().isoformat()
+    since = (datetime.now(tz=UTC) - timedelta(days=1)).isoformat()
+    until = datetime.now(tz=UTC).isoformat()
     incidents_list = await incidents.list_incidents(
         team_ids=team_ids, limit=1, since=since, until=until
     )

--- a/tests/integration/test_oncalls_integration.py
+++ b/tests/integration/test_oncalls_integration.py
@@ -1,9 +1,9 @@
 """Integration tests for the oncalls module."""
 
 import pytest
-from tests.conftest import skip_if_no_pagerduty_key
 
 from pagerduty_mcp_server import oncalls
+from tests.conftest import skip_if_no_pagerduty_key
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_schedules_integration.py
+++ b/tests/integration/test_schedules_integration.py
@@ -1,7 +1,7 @@
 import pytest
-from tests.conftest import skip_if_no_pagerduty_key
 
 from pagerduty_mcp_server import schedules
+from tests.conftest import skip_if_no_pagerduty_key
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_services_integration.py
+++ b/tests/integration/test_services_integration.py
@@ -1,7 +1,7 @@
 import pytest
-from tests.conftest import skip_if_no_pagerduty_key
 
 from pagerduty_mcp_server import services
+from tests.conftest import skip_if_no_pagerduty_key
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_teams_integration.py
+++ b/tests/integration/test_teams_integration.py
@@ -1,7 +1,7 @@
 import pytest
-from tests.conftest import skip_if_no_pagerduty_key
 
 from pagerduty_mcp_server import teams
+from tests.conftest import skip_if_no_pagerduty_key
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_users_integration.py
+++ b/tests/integration/test_users_integration.py
@@ -1,7 +1,7 @@
 import pytest
-from tests.conftest import skip_if_no_pagerduty_key
 
 from pagerduty_mcp_server import users
+from tests.conftest import skip_if_no_pagerduty_key
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_async_utils_unit.py
+++ b/tests/unit/test_async_utils_unit.py
@@ -4,6 +4,7 @@ import threading
 from unittest.mock import MagicMock
 
 import pytest
+
 from pagerduty_mcp_server.async_utils import paginate, safe_execute_async
 
 

--- a/tests/unit/test_client_unit.py
+++ b/tests/unit/test_client_unit.py
@@ -32,18 +32,20 @@ def test_create_client_with_request_token():
     mock_request = MagicMock(spec=Request)
     mock_request.headers = {"X-PagerDuty-Token": "request-token"}
 
-    with patch(
-        "pagerduty_mcp_server.client._RestClient", return_value=mock_client
-    ) as mock_client_class:
-        with patch(
+    with (
+        patch(
+            "pagerduty_mcp_server.client._RestClient", return_value=mock_client
+        ) as mock_client_class,
+        patch(
             "pagerduty_mcp_server.client.get_http_request", return_value=mock_request
-        ):
-            with patch.dict("os.environ", {"PAGERDUTY_API_TOKEN": "env-token"}):
-                create_client()
-                create_client()
+        ),
+        patch.dict("os.environ", {"PAGERDUTY_API_TOKEN": "env-token"}),
+    ):
+        create_client()
+        create_client()
 
-                assert mock_client_class.call_count == 2
-                mock_client_class.assert_called_with("request-token")
+        assert mock_client_class.call_count == 2
+        mock_client_class.assert_called_with("request-token")
 
 
 @pytest.mark.unit
@@ -52,18 +54,18 @@ def test_create_client_with_env_token_singleton():
     """Test that create_client() reuses instance with env token."""
     mock_client = MagicMock()
 
-    with patch(
-        "pagerduty_mcp_server.client._RestClient", return_value=mock_client
-    ) as mock_client_class:
-        with patch(
-            "pagerduty_mcp_server.client.get_http_request", side_effect=RuntimeError
-        ):
-            with patch.dict("os.environ", {"PAGERDUTY_API_TOKEN": "env-token"}):
-                client1 = create_client()
-                client2 = create_client()
+    with (
+        patch(
+            "pagerduty_mcp_server.client._RestClient", return_value=mock_client
+        ) as mock_client_class,
+        patch("pagerduty_mcp_server.client.get_http_request", side_effect=RuntimeError),
+        patch.dict("os.environ", {"PAGERDUTY_API_TOKEN": "env-token"}),
+    ):
+        client1 = create_client()
+        client2 = create_client()
 
-                mock_client_class.assert_called_once_with("env-token")
-                assert client1 is client2
+        mock_client_class.assert_called_once_with("env-token")
+        assert client1 is client2
 
 
 @pytest.mark.unit
@@ -76,17 +78,19 @@ def test_token_precedence():
     mock_request = MagicMock(spec=Request)
     mock_request.headers = {"X-PagerDuty-Token": "header-token"}
 
-    with patch(
-        "pagerduty_mcp_server.client._RestClient",
-        side_effect=[mock_header_client, mock_env_client],
-    ) as mock_client_class:
-        with patch(
+    with (
+        patch(
+            "pagerduty_mcp_server.client._RestClient",
+            side_effect=[mock_header_client, mock_env_client],
+        ) as mock_client_class,
+        patch(
             "pagerduty_mcp_server.client.get_http_request", return_value=mock_request
-        ):
-            with patch.dict("os.environ", {"PAGERDUTY_API_TOKEN": "env-token"}):
-                create_client()
+        ),
+        patch.dict("os.environ", {"PAGERDUTY_API_TOKEN": "env-token"}),
+    ):
+        create_client()
 
-                mock_client_class.assert_called_once_with("header-token")
+        mock_client_class.assert_called_once_with("header-token")
 
 
 @pytest.mark.unit
@@ -106,25 +110,27 @@ def test_create_client_no_token(monkeypatch):
     # Create a fresh instance to avoid any class-level caching
     test_client = PagerDutyClient()
 
-    with patch("pagerduty_mcp_server.client._RestClient") as mock_client_class:
-        with patch(
+    with (
+        patch("pagerduty_mcp_server.client._RestClient") as mock_client_class,
+        patch(
             "pagerduty_mcp_server.client.get_http_request", return_value=mock_request
-        ):
-            # Verify our setup is clean
-            assert test_client._env_client is None
-            assert PagerDutyClient._env_client is None
-            assert test_client._get_request_token() == (True, None)
-            assert test_client._get_env_token() is None
+        ),
+    ):
+        # Verify our setup is clean
+        assert test_client._env_client is None
+        assert PagerDutyClient._env_client is None
+        assert test_client._get_request_token() == (True, None)
+        assert test_client._get_env_token() is None
 
-            # Test the error is raised
-            with pytest.raises(PagerDutyAuthError) as exc_info:
-                test_client.get_client()
+        # Test the error is raised
+        with pytest.raises(PagerDutyAuthError) as exc_info:
+            test_client.get_client()
 
-            # In request context with no token the request-context error fires first
-            assert "PagerDuty credentials are not configured for this request" in str(
-                exc_info.value
-            )
-            mock_client_class.assert_not_called()
+        # In request context with no token the request-context error fires first
+        assert "PagerDuty credentials are not configured for this request" in str(
+            exc_info.value
+        )
+        mock_client_class.assert_not_called()
 
 
 @pytest.mark.unit
@@ -223,24 +229,24 @@ def test_env_client_recreated_on_token_rotation():
     mock_client_a = MagicMock()
     mock_client_b = MagicMock()
 
-    with patch(
-        "pagerduty_mcp_server.client._RestClient",
-        side_effect=[mock_client_a, mock_client_b],
-    ) as mock_client_class:
-        with patch(
-            "pagerduty_mcp_server.client.get_http_request", side_effect=RuntimeError
-        ):
-            # First call with token "a"
-            with patch.dict("os.environ", {"PAGERDUTY_API_TOKEN": "token-a"}):
-                client1 = create_client()
-                assert client1 is mock_client_a
-                mock_client_class.assert_called_once_with("token-a")
+    with (
+        patch(
+            "pagerduty_mcp_server.client._RestClient",
+            side_effect=[mock_client_a, mock_client_b],
+        ) as mock_client_class,
+        patch("pagerduty_mcp_server.client.get_http_request", side_effect=RuntimeError),
+    ):
+        # First call with token "a"
+        with patch.dict("os.environ", {"PAGERDUTY_API_TOKEN": "token-a"}):
+            client1 = create_client()
+            assert client1 is mock_client_a
+            mock_client_class.assert_called_once_with("token-a")
 
-            # Second call with different token "b"
-            with patch.dict("os.environ", {"PAGERDUTY_API_TOKEN": "token-b"}):
-                client2 = create_client()
-                assert client2 is mock_client_b
-                assert mock_client_class.call_count == 2
+        # Second call with different token "b"
+        with patch.dict("os.environ", {"PAGERDUTY_API_TOKEN": "token-b"}):
+            client2 = create_client()
+            assert client2 is mock_client_b
+            assert mock_client_class.call_count == 2
 
 
 @pytest.mark.unit

--- a/tests/unit/test_escalation_policies_unit.py
+++ b/tests/unit/test_escalation_policies_unit.py
@@ -111,7 +111,7 @@ async def test_fetch_escalation_policy_ids(
         escalation_policies.ESCALATION_POLICIES_URL,
         params={"user_ids[]": [mock_user["id"]]},
     )
-    assert set(policy_ids) == set([policy["id"] for policy in mock_escalation_policies])
+    assert set(policy_ids) == {policy["id"] for policy in mock_escalation_policies}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_incidents_unit.py
+++ b/tests/unit/test_incidents_unit.py
@@ -1050,13 +1050,15 @@ async def test_get_current_user_email_api_call(monkeypatch):
 async def test_get_current_user_email_failure(monkeypatch):
     """Test RuntimeError when email cannot be determined."""
     monkeypatch.delenv("PAGERDUTY_USER_EMAIL", raising=False)
-    with patch(
-        "pagerduty_mcp_server.users.build_user_context",
-        new_callable=AsyncMock,
-        return_value={"email": ""},
+    with (
+        patch(
+            "pagerduty_mcp_server.users.build_user_context",
+            new_callable=AsyncMock,
+            return_value={"email": ""},
+        ),
+        pytest.raises(RuntimeError, match="Cannot determine current user email"),
     ):
-        with pytest.raises(RuntimeError, match="Cannot determine current user email"):
-            await incidents._get_current_user_email()
+        await incidents._get_current_user_email()
 
 
 @pytest.mark.unit

--- a/tests/unit/test_notes_unit.py
+++ b/tests/unit/test_notes_unit.py
@@ -5,7 +5,6 @@ import pytest
 from pagerduty_mcp_server import incidents, utils
 from pagerduty_mcp_server.models.note import Note
 
-
 """
 Note Model Tests
 """

--- a/tests/unit/test_schedules_unit.py
+++ b/tests/unit/test_schedules_unit.py
@@ -1,6 +1,6 @@
 """Unit tests for the schedules module."""
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock
 
 import pytest
@@ -176,8 +176,8 @@ async def test_list_users_oncall(mock_get_api_client, mock_schedules):
 async def test_list_users_oncall_with_date_range(mock_get_api_client, mock_schedules):
     """Test that users on call can be fetched with date range parameters."""
     schedule_id = mock_schedules[0]["id"]
-    since = (datetime.now() - timedelta(days=7)).isoformat()
-    until = datetime.now().isoformat()
+    since = (datetime.now(tz=UTC) - timedelta(days=7)).isoformat()
+    until = datetime.now(tz=UTC).isoformat()
     mock_users_data = [
         {"id": "P789012", "summary": "John Doe", "email": "john.doe@example.com"}
     ]

--- a/tests/unit/test_services_unit.py
+++ b/tests/unit/test_services_unit.py
@@ -117,7 +117,7 @@ async def test_fetch_service_ids(mock_get_api_client, mock_services, mock_team_i
     mock_get_api_client.list_all.assert_called_once_with(
         services.SERVICES_URL, params={"team_ids[]": mock_team_ids}
     )
-    assert set(service_ids) == set([service["id"] for service in mock_services])
+    assert set(service_ids) == {service["id"] for service in mock_services}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
`uvx ruff` downloads the latest ruff tool independently of the pinned `ruff>=0.11.2` dev dependency. When ruff 0.16.x tightened and added rules (UP035, UP006, C401, RUF022, and others), CI began failing on PRs that touch `.python-version` (e.g. the Renovate PR bumping to 3.14) even though the errors existed on 3.13 as well — main branch CI was simply last run against an older ruff.

## Changes

**`pyproject.toml`** — adds a `[tool.ruff]` section:
- `target-version = "py313"`: pins ruff's target so lint behavior never varies with whatever `.python-version` contains. This is the primary guard against future `.python-version` bumps breaking CI.
- `ignore = ["BLE001", "RUF012"]`: suppresses two rule classes that are intentional patterns. `BLE001` broad exception catches are used consistently throughout the codebase to route all API errors to `utils.handle_api_error`. `RUF012` mutable class-attribute defaults are false positives for Pydantic `BaseModel` subclasses, which handle mutable defaults safely; ruff cannot always detect the inheritance through a custom base class.

**Source and test files** — fixes for the remaining 57 errors ruff auto-fix couldn't handle:
- Deprecated `typing.Dict`, `typing.List`, `typing.Callable` imports replaced with built-in `dict`, `list`, `collections.abc.Callable`
- `raise Exception(...)` in `auth.py` changed to `raise RuntimeError(...)`
- `.replace("Z", "+00:00")` removed from `datetime.fromisoformat()` calls in `utils.py`; Python 3.11+ parses `"Z"` natively
- Naive `datetime.now()` in tests made timezone-aware with `datetime.now(tz=UTC)`
- Minor style: nested `with` merged, `set([list comp])` rewritten as set comprehensions, `dict.keys()` iteration simplified

Lint and format pass with `.python-version` at both `3.13` and `3.14`.